### PR TITLE
fix(client): redirect not converting request to GET

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -199,6 +199,8 @@ class Client
             $uri = $new_request->getUri();
             $url = (string)$uri;
             $options = $new_request->getOptions();
+            $options['method'] = 'GET';
+            $options['data'] = NULL;
             $address = $this->parseAddress($url);
             $task = [
                 'url'      => $url,


### PR DESCRIPTION
修复在重定向后会把原来的请求方法(例如POST)和数据继续交付给下一个页面